### PR TITLE
Fix for @import Placement Error

### DIFF
--- a/pos-frontend/src/index.css
+++ b/pos-frontend/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 
 body {
   font-family: 'Inter', sans-serif;


### PR DESCRIPTION
### **Issue Reference**  
Fixes #3 

### **Description**  
This PR moves the `@import` statement to the top of the CSS file to fix the Vite + TailwindCSS error:  
```plaintext
[vite:css][postcss] @import must precede all other statements (besides @charset or empty @layer)
```

### **Changes Made**  
- Moved `@import` before Tailwind directives.  

### **How to Test**  
1. Pull this branch
2. Run `npm run dev`.  
3. The error should no longer appear.  
